### PR TITLE
Handle unrecognised device types from the Tapo API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 
 # misc
 .DS_Store
+# raycast
+raycast-env.d.ts
+/dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Tapo Smart Devices Changelog
 
+## [Fix crash on unrecognised device types] - {PR_MERGE_DATE}
+
+* Gracefully ignore devices with a type not recognised by the extension, rather than crashing when the Tapo API returns an unknown device type
+
 ## [v1.1.0] - 2022-08-11
 
 * Add support for turning devices on and off from the menu bar

--- a/src/devices.ts
+++ b/src/devices.ts
@@ -5,7 +5,7 @@ import { cloudLogin, loginDeviceByIp, TapoDevice } from "tp-link-tapo-connect";
 import { AvailableDevice, Device, DeviceStatusEnum, DeviceTypeEnum, Preferences } from "./types";
 import { normaliseMacAddress } from "./utils";
 
-const tapoDeviceTypeToDeviceType = (tapoDeviceType: string): DeviceTypeEnum => {
+const tapoDeviceTypeToDeviceType = (tapoDeviceType: string): DeviceTypeEnum | null => {
   switch (tapoDeviceType) {
     case "SMART.TAPOPLUG":
       return DeviceTypeEnum.Plug;
@@ -14,21 +14,31 @@ const tapoDeviceTypeToDeviceType = (tapoDeviceType: string): DeviceTypeEnum => {
     case "HOMEWIFISYSTEM":
       return DeviceTypeEnum.HomeWifiSystem;
     default:
-      throw `Device type ${tapoDeviceType} not supported`;
+      // The Tapo API can return device types we don't recognise. Rather than
+      // crashing, we return `null` so the device can be filtered out.
+      return null;
   }
 };
 
-const tapoDeviceToDevice = (tapoDevice: TapoDevice): Device => ({
-  id: tapoDevice.deviceId,
-  type: tapoDeviceTypeToDeviceType(tapoDevice.deviceType),
-  macAddress: tapoDevice.deviceMac,
-  name: `Tapo ${tapoDevice.deviceName}`,
-  alias: tapoDevice.alias,
-  status: DeviceStatusEnum.Loading,
-  isTurnedOn: null,
-  ipAddress: null,
-  loggedInDevice: null,
-});
+const tapoDeviceToDevice = (tapoDevice: TapoDevice): Device | null => {
+  const type = tapoDeviceTypeToDeviceType(tapoDevice.deviceType);
+
+  if (type === null) {
+    return null;
+  }
+
+  return {
+    id: tapoDevice.deviceId,
+    type,
+    macAddress: tapoDevice.deviceMac,
+    name: `Tapo ${tapoDevice.deviceName}`,
+    alias: tapoDevice.alias,
+    status: DeviceStatusEnum.Loading,
+    isTurnedOn: null,
+    ipAddress: null,
+    loggedInDevice: null,
+  };
+};
 
 const isSupportedDevice = (device: Device): boolean =>
   device.type === DeviceTypeEnum.Plug || device.type === DeviceTypeEnum.Bulb;
@@ -39,7 +49,10 @@ export const getDevices = async (): Promise<Device[]> => {
   const cloudApi = await cloudLogin(email, password);
   const tapoDevices = await cloudApi.listDevices();
 
-  return tapoDevices.map(tapoDeviceToDevice).filter(isSupportedDevice);
+  return tapoDevices
+    .map(tapoDeviceToDevice)
+    .filter((device): device is Device => device !== null)
+    .filter(isSupportedDevice);
 };
 
 export const turnDeviceOn = async (device: AvailableDevice): Promise<void> => {


### PR DESCRIPTION
## What & why

Previously, if the Tapo cloud API returned a device with a type the extension didn't recognise, `tapoDeviceTypeToDeviceType` would throw a hard error. Because this happens inside `getDevices`' `map`, a single unknown device would crash the whole extension, leaving the user unable to see or control any of their devices.

## Changes

- `tapoDeviceTypeToDeviceType` now returns `null` for unrecognised device types instead of throwing.
- `tapoDeviceToDevice` returns `null` when the type can't be mapped.
- `getDevices` filters out those `null` entries before the existing supported-device filter, so unknown devices are quietly ignored and the rest continue to work.
- Added a `CHANGELOG.md` entry following Raycast conventions.
- Gitignored the generated `raycast-env.d.ts` and `dist` artifacts.

## Testing

- `npm run lint` passes
- `npm run build` passes (TypeScript type-checks cleanly)